### PR TITLE
remove tauri-cli installation step from release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -135,9 +135,6 @@ jobs:
           name: sveltekit-build
           path: ./apps/android/build
 
-      - name: install tauri-cli
-        run: cargo install tauri-cli@2.1.0
-
       - name: build tauri
         shell: bash
         run: |


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yaml` file. The change removes the installation step for `tauri-cli`.

Changes in `jobs:`:

* [`.github/workflows/release.yaml`](diffhunk://#diff-e426ed45842837026e10e66af23d9c7077e89eacbe6958ce7cb991130ad05adaL138-L140): Removed the step to install `tauri-cli` using `cargo` in the `sveltekit-build` job.