### PR TITLE
update tauri command to use bun instead of bunx in release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -14,6 +14,7 @@
     "lint": "biome lint --write .",
     "format": "biome format --write .",
     "rustfmt": "cargo +nightly-2024-11-15 fmt -- --config-path rustfmt-nightly.toml",
+    "tauri": "bunx tauri",
     "build:android": "turbo run --filter @seminar-assess/android build --no-daemon"
   },
   "workspaces": ["apps/*", "packages/*"]

--- a/scripts/release.sh
+++ b/scripts/release.sh
@@ -36,7 +36,7 @@ CONFIG_PATH=""
 DIST="release"
 
 function tauri() {
-  (cd "$PWD/.." && bunx tauri "$@")
+  (cd "$PWD/.." && bun tauri "$@")
 }
 
 while [[ $# -gt 0 ]]; do


### PR DESCRIPTION
This pull request includes changes to the `package.json` and `scripts/release.sh` files to update the Tauri command.

Updates to Tauri command:

* [`package.json`](diffhunk://#diff-7ae45ad102eab3b6d7e7896acd08c427a9b25b346470d7bc6507b6481575d519R17): Added a new script command `"tauri": "bunx tauri"` to the scripts section.
* [`scripts/release.sh`](diffhunk://#diff-1bba00e5aca52286a667c09eff92ba2ca8e3ca77e0d31b0599cc829ab0173389L39-R39): Modified the `tauri` function to use `bun tauri` instead of `bunx tauri`.