### PR TITLE
add step to install frontend dependencies in release workflow

### DIFF
--- a/.github/workflows/release.yaml
+++ b/.github/workflows/release.yaml
@@ -101,6 +101,9 @@ jobs:
         with:
           bun-version: latest
 
+      - name: install frontend dependencies
+        run: bun install
+
       - name: setup rust nightly
         uses: actions-rust-lang/setup-rust-toolchain@v1
 


### PR DESCRIPTION
This pull request includes a small change to the `.github/workflows/release.yaml` file. The change adds a step to install frontend dependencies using `bun`.